### PR TITLE
fix: multiline imports

### DIFF
--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -5,13 +5,20 @@ import { scanDirectories } from '../utils/scan-directories'
 import extractImports from '../utils/extract-imports'
 import { appendFileSync } from 'fs'
 
-let importCount = 0
-let importResults: ImportResult[] = []
-let importsUsed: ImportsUsed = {
+export let importCount = 0
+export let importResults: ImportResult[] = []
+export let importsUsed: ImportsUsed = {
 	default: {},
 	named: {},
 }
-let importsCount: Import = {}
+export let importsCount: Import = {}
+
+export function resetScanGlobals() {
+	importCount = 0
+	importResults = []
+	importsUsed = { default: {}, named: {} }
+	importsCount = {}
+}
 
 export async function scan(options: {
 	directory: string

--- a/src/utils/file-contains-import.ts
+++ b/src/utils/file-contains-import.ts
@@ -16,7 +16,7 @@ export function fileContainsImport(
 	const fileContent = fs.readFileSync(filePath, 'utf8')
 
 	if (
-		new RegExp(`import.*from\\s+["']${importName}["']`, 'm').test(fileContent)
+		new RegExp(`import.*?from\\s+["']${importName}["']`, 'ms').test(fileContent)
 	) {
 		return { filePath, fileContent }
 	}


### PR DESCRIPTION
Fixes support for multiline imports. Previously, it was only working for one-liner imports

```ts
// importtest.ts
const Foo = "foo"
const Bar = "bar"
```

```ts
// otherfile.ts
import {
Foo,
Bar
} from "./importtest.ts"
```

When you run this, it will show no result
```bash
node dist/index.js scan -d test -i ./importme.ts -ext .tsx,.ts
```

Result:

```bash
No files found with "./importme.ts" imports across directory /Users/aminroslan/Projects/Qwerqy/scan-imports/test.
```

After fix, this is the result:

```bash
Found 1 files with "./importme.ts" imports across directory /Users/aminroslan/Projects/Qwerqy/scan-imports/test:
{
  "default": {},
  "named": {
    "Foo": 1,
    "Bar": 1
  }
}
```

Fix for issue #15 